### PR TITLE
Fix type export for cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   },
   "exports": {
     "import": "./target/esm/main.mjs",
-    "require": "./target/cjs/main.cjs"
+    "require": "./target/cjs/main.cjs",
+    "types": "./target/types/index.d.ts"
   },
   "files": [
     "/target",


### PR DESCRIPTION
This PR fixes the following error, when trying to import `rrule-es` in a CommonJS project.
 
```
TS7016: Could not find a declaration file for module 'rrule-es'. '.../rrule-es@1.0.0/node_modules/rrule-es/target/cjs/main.cjs' implicitly has an 'any' type.
    Try `npm i --save-dev @types/rrule-es` if it exists or add a new declaration (.d.ts) file containing `declare module 'rrule-es';`
```